### PR TITLE
fix: add last year replacement, fix january 2nd title

### DIFF
--- a/lib/holidays.js
+++ b/lib/holidays.js
@@ -5,7 +5,7 @@ export const holidays = {
       "Celebrate the start of yet another year. Not much has changed, but it’s a reason to party.",
   },
   "01-02": {
-    title: "Celebrate Surviving {year} Day 🗓️",
+    title: "Celebrate Surviving {lastyear} Day 🗓️",
     description:
       "You made it through another year! Time to pat yourself on the back for surviving.",
   },

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,11 +9,13 @@ export function getHoliday(date) {
   const title =
     template?.title
       ?.replace("{year}", date.getFullYear())
-      ?.replace("{nextyear}", date.getFullYear() + 1) ?? "error";
+        ?.replace("{nextyear}", date.getFullYear() + 1)
+        ?.replace("{lastyear}", date.getFullYear() - 1) ?? "error";
   const description =
     template?.description
       ?.replace("{year}", date.getFullYear())
-      ?.replace("{nextyear}", date.getFullYear() + 1) ?? "error";
+        ?.replace("{nextyear}", date.getFullYear() + 1)
+        ?.replace("{lastyear}", date.getFullYear() - 1) ?? "error";
 
   return { title, description };
 }


### PR DESCRIPTION
The January 2nd title says: Celebrate Surviving 2026 Day (in 2026-01-02)
I think the original intent was to celebrate surviving the last year not current.

[bug: show correct year on january 2nd description](https://github.com/salitha-pathi/gnome-pastafarian-holidays/issues/1)